### PR TITLE
Added userspace code to allow use of new syscalls

### DIFF
--- a/include/litmus.h
+++ b/include/litmus.h
@@ -416,6 +416,19 @@ int null_call(cycles_t *timestamp);
  */
 struct control_page* get_ctrl_page(void);
 
+/**
+ * Check if budget for current job has been exhausted
+ * @param bBudgetExhausted Stores answer
+ *  */
+int budget_exhausted(int *bBudgetExhausted);
+
+/**
+ * Get the slack for current job before deadline
+ * @param slack Stores slack answer
+ *  */
+int get_slack(lt_t* slack);
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/syscalls.c
+++ b/src/syscalls.c
@@ -86,3 +86,13 @@ int null_call(cycles_t *timestamp)
 {
 	return syscall(__NR_null_call, timestamp);
 }
+
+int budget_exhausted(int *bBudgetExhausted)
+{
+	return syscall(__NR_query_budget_exhausted, bBudgetExhausted);
+}
+
+int get_slack(lt_t *slack)
+{
+	return syscall(__NR_query_slack_time, slack);
+}


### PR DESCRIPTION
This is just the associated patch to go with the litmus-rt patch. 
- budget_exhausted(int*): Sets the flag if the budget for the current job has been exhausted
- get_slack(lt_t*): Gets the remaining time until the deadline for the current job is reached
